### PR TITLE
Handle cases where portions of 511 API response are Null

### DIFF
--- a/server/app.py
+++ b/server/app.py
@@ -148,8 +148,8 @@ def helper_thread():
             update_cache()
             logging.debug("helper thread updated cache with predictions")
             MetricsHandler.cache_last_updated.set(int(time.time()))
-        except Exception as e:
-            logging.exception(f"Exception in helper_thread: {e}")
+        except Exception:
+            logging.exception("Unable to update cache")
             continue
         time.sleep(60 * cache_update_interval)
 

--- a/server/app.py
+++ b/server/app.py
@@ -118,17 +118,8 @@ def get_stop_predictions(stop_ids, operator, stop_name):
         all_incoming_buses = data.get('ServiceDelivery', {}).get('StopMonitoringDelivery', {}).get('MonitoredStopVisit')
         for bus in all_incoming_buses:
             route_name = bus.get('MonitoredVehicleJourney', {}).get('LineRef')
-            monitored_call = bus.get('MonitoredVehicleJourney', {}).get('MonitoredCall', {})
-
-            route_destination = monitored_call.get('DestinationDisplay')
-
-            # handle potential null destination error
-            if route_destination is not None:
-                route_destination = route_destination.title()
-            else:
-                route_destination = "Unknown Destination"
-
-            expected_arrival = monitored_call.get('AimedArrivalTime')
+            route_destination = bus.get('MonitoredVehicleJourney', {}).get('MonitoredCall', {}).get('DestinationDisplay', 'Unknown Destination').title()
+            expected_arrival = bus.get('MonitoredVehicleJourney', {}).get('MonitoredCall', {}).get('AimedArrivalTime')
                 
             unique_buses[route_name].route = route_name
             unique_buses[route_name].destinations[route_destination].append(expected_arrival)

--- a/server/app.py
+++ b/server/app.py
@@ -150,6 +150,7 @@ def helper_thread():
             MetricsHandler.cache_last_updated.set(int(time.time()))
         except Exception:
             logging.exception("Unable to update cache")
+            MetricsHandler.cache_update_errors.inc() 
             continue
         time.sleep(60 * cache_update_interval)
 

--- a/server/modules/metrics.py
+++ b/server/modules/metrics.py
@@ -20,6 +20,11 @@ class Metrics(enum.Enum):
         "Timestamp of when our cache was last updated",
         prometheus_client.Gauge,
     )
+    CACHE_UPDATE_ERRORS = (
+        "cache_update_errors",
+        "Number of times the cache fails to update",
+        prometheus_client.Counter,
+    )
     HTTP_CODE = (
         "http_code",
         "Count of each HTTP Response code",


### PR DESCRIPTION
```
File "/server/app.py", line 121, in get_stop_predictions
route_destination = bus.get('MonitoredVehicleJourney', {}).get('MonitoredCall', {}).get('DestinationDisplay').title()
AttributeError: 'NoneType' object has no attribute 'title'
```
Should resolve this error where 511 API call has a valid bus but a null destination

Adds change to restart the helper thread upon an Exception rather than staying dead (in hopes that successive call to 511 API lacks the error before)